### PR TITLE
Serve SPA from Express build output

### DIFF
--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -1,14 +1,19 @@
 import express, { Request, Response } from "express";
+import path from "path";
 
 const app = express();
+
+const distDir = path.resolve(__dirname, "..");
+
+app.use(express.static(distDir));
 
 app.get("/health", (_req: Request, res: Response) => {
   res.set("Content-Type", "application/json");
   res.status(200).json({ status: "ok" });
 });
 
-app.get("/", (_req: Request, res: Response) => {
-  res.status(200).send("OK");
+app.get("*", (_req: Request, res: Response) => {
+  res.sendFile(path.join(distDir, "index.html"));
 });
 
 const port = Number(process.env.PORT ?? 8080);


### PR DESCRIPTION
## Summary
- serve the built SPA assets from the dist directory using express.static
- add a catch-all handler that sends dist/index.html while preserving the /health endpoint

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_b_69028a3a7f30832e8fb5eda227fed0dd